### PR TITLE
build: buildGradle'da alınan hata giderildi.

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 }
 
 android {
+	namespace 'com.artifex.mupdf'
 	compileSdkVersion 31
 	defaultConfig {
 		minSdkVersion 21


### PR DESCRIPTION
build: galepress gradle sürümleri güncellendiğinden muPDF için de gredle içinde namespace 'com.artifex.mupdf' eklendi